### PR TITLE
translating header to FR & NL

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,7 @@
       integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
       crossorigin="anonymous"
     ></script>
+    <script src="https://unpkg.com/vue-i18n@9"></script>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,30 +1,37 @@
 <script>
-import { mapState } from 'vuex';
+import { mapState } from "vuex";
+
 export default {
   data() {
     return {
       hidden: true,
+      locale: "ENG",
     };
   },
+  watch: {
+    locale(val) {
+      this.$i18n.locale = val;
+    },
+  },
   computed: {
-    ...mapState(['isLoggedIn', 'user']),
+    ...mapState(["isLoggedIn", "user"]),
   },
   methods: {
     logout() {
-      const token = localStorage.getItem('token');
+      const token = localStorage.getItem("token");
       const userId = this.user.userId;
       fetch(`http://localhost:5000/users/logout/${userId}`, {
-        method: 'GET',
+        method: "GET",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           authorization: `Bearer ${token}`,
         },
       })
         .then((res) => {
           console.log(res);
-          localStorage.removeItem('token');
-          this.$store.commit('loggedOut');
-          this.$router.push('/');
+          localStorage.removeItem("token");
+          this.$store.commit("loggedOut");
+          this.$router.push("/");
         })
         .catch((err) => {
           console.log(err);
@@ -52,22 +59,24 @@ export default {
             class="header__nav-list link"
             >About</router-link
           >
-          <a v-else href="#about" class="header__nav-list link">About</a>
+          <a v-else href="#about" class="header__nav-list link">{{
+            $t("about")
+          }}</a>
         </li>
         <li class="header__nav-list item">
-          <router-link to="/volunteers" class="header__nav-list link"
-            >Volunteers</router-link
-          >
+          <router-link to="/volunteers" class="header__nav-list link">{{
+            $t("volunteers")
+          }}</router-link>
         </li>
         <li class="header__nav-list item">
-          <router-link to="/contacts" class="header__nav-list link"
-            >Contact Us</router-link
-          >
+          <router-link to="/contacts" class="header__nav-list link">{{
+            $t("contactus")
+          }}</router-link>
         </li>
       </ul>
       <ul class="header__nav-features">
         <li class="header__nav-features select">
-          <select>
+          <select v-model="locale">
             <option class="header__nav-features option">ENG</option>
             <option class="header__nav-features option">FR</option>
             <option class="header__nav-features option">NL</option>
@@ -108,10 +117,12 @@ export default {
             class="usermenu-list"
             :class="{ 'foo-hover': hidden }"
           >
-            
-            <router-link to="/myprofile" class="usermenu-a" id="usermenu-profile"
-            >My profile</router-link
-          ><br/>
+            <router-link
+              to="/myprofile"
+              class="usermenu-a"
+              id="usermenu-profile"
+              >My profile</router-link
+            ><br />
             <a @click="logout" href="#" class="usermenu-a" id="usermenu-logout"
               >Logout</a
             >
@@ -123,8 +134,8 @@ export default {
 </template>
 
 <style lang="scss">
-@import '../components/styles/abstract/_variables.scss';
-@import '../components/styles/layout/_header.scss';
+@import "../components/styles/abstract/_variables.scss";
+@import "../components/styles/layout/_header.scss";
 
 .foo-hover {
   display: none;

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,0 +1,25 @@
+import { createI18n } from "vue-i18n";
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "ENG",
+  globalInjection: true,
+  messages: {
+    ENG: {
+      about: "About",
+      volunteers: "Volunteers",
+      contactus: "Contact Us",
+    },
+    FR: {
+      about: "À propos de nous",
+      volunteers: "Bénévoles",
+      contactus: "Contactez nous",
+    },
+    NL: {
+      about: "Over ons",
+      volunteers: "Vrijwilligers",
+      contactus: "Contacteer Ons",
+    },
+  },
+});
+export default i18n;

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -11,9 +11,9 @@ const i18n = createI18n({
       contactus: "Contact Us",
     },
     FR: {
-      about: "À propos de nous",
+      about: "À propos",
       volunteers: "Bénévoles",
-      contactus: "Contactez nous",
+      contactus: "Contactez-nous",
     },
     NL: {
       about: "Over ons",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,15 +1,16 @@
-import { createApp } from 'vue';
+import { createApp } from "vue";
 
-import App from './App.vue';
-import router from './router';
-import store from './store';
-import { FontAwesomeIcon } from './assets/js/font-awesome';
-import vSelect from 'vue-select';
+import App from "./App.vue";
+import router from "./router";
+import store from "./store";
+import { FontAwesomeIcon } from "./assets/js/font-awesome";
+import vSelect from "vue-select";
+import i18n from "./i18n";
 
 createApp(App)
   .use(router)
   .use(store)
-  .component('font-awesome-icon', FontAwesomeIcon)
-  .component('v-select', vSelect)
-  .mount('#app');
-
+  .use(i18n)
+  .component("font-awesome-icon", FontAwesomeIcon)
+  .component("v-select", vSelect)
+  .mount("#app");

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "mongoose": "^6.1.4",
         "nodemon": "^2.0.15",
         "vue": "^3.2.25",
+        "vue-i18n": "^9.2.0-beta.26",
         "vue-jwt-decode": "^0.1.0",
         "vue-router": "^4.0.12",
         "vue-select": "^4.0.0-beta.2",
@@ -89,6 +90,63 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || >=1.3.0-beta1",
         "vue": ">= 3.0.0 < 4"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.2.0-beta.26.tgz",
+      "integrity": "sha512-4OXSF0zC70UElev6gam4FdWfC7u4l2ouNK9Hc6R44QlpEXkzhbwwbpZn9gIGB2l11zQnJkAwaovfYyiNJ/JvkA==",
+      "dependencies": {
+        "@intlify/devtools-if": "9.2.0-beta.26",
+        "@intlify/message-compiler": "9.2.0-beta.26",
+        "@intlify/shared": "9.2.0-beta.26",
+        "@intlify/vue-devtools": "9.2.0-beta.26"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@intlify/devtools-if": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-if/-/devtools-if-9.2.0-beta.26.tgz",
+      "integrity": "sha512-7GiF7v2jlHf7g5hoLF6sKlrX5Di2INfHN4PEAeVr2ashgoSaq1EYIRouBVAnJkOrDOJzCOEY7y53me7+gIbeTw==",
+      "dependencies": {
+        "@intlify/shared": "9.2.0-beta.26"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.2.0-beta.26.tgz",
+      "integrity": "sha512-qtDgHCMqrXNTekKXGzm0Dm6r3+/X7/jFXP+E07hx+PJbPMv7DzK1iU8h5LlAMQ1/jr2UIRBgXvR5wh35OKoGrA==",
+      "dependencies": {
+        "@intlify/shared": "9.2.0-beta.26",
+        "source-map": "0.6.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.2.0-beta.26.tgz",
+      "integrity": "sha512-MjUlkjNThqkqy8yXUcFKBiW/hIfqAn5cP3Vd0b4wdOHS8rPCEbvSbAnF08uiZDkVv8gTcsLyymX21GaU6oYyyQ==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@intlify/vue-devtools": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-devtools/-/vue-devtools-9.2.0-beta.26.tgz",
+      "integrity": "sha512-Ghe2xTSezRzL2fBdIbZEus5+5spE2RMxgjBg6GyvbsDy1M05o2OvukBninJ4/Tc2I5A30lYgAsF1gQlOyfmv1g==",
+      "dependencies": {
+        "@intlify/core-base": "9.2.0-beta.26",
+        "@intlify/shared": "9.2.0-beta.26"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@sendgrid/client": {
@@ -2659,6 +2717,23 @@
         "@vue/shared": "3.2.26"
       }
     },
+    "node_modules/vue-i18n": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.2.0-beta.26.tgz",
+      "integrity": "sha512-xZgisyirT9hXFyXBL8pO8bYgdG7m98NLAUhbb1O9hMQS1qOXYU902+LIJA5k3BtoeiEIfjkGADHhSAlJTTzc9A==",
+      "dependencies": {
+        "@intlify/core-base": "9.2.0-beta.26",
+        "@intlify/shared": "9.2.0-beta.26",
+        "@intlify/vue-devtools": "9.2.0-beta.26",
+        "@vue/devtools-api": "^6.0.0-beta.13"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-jwt-decode": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/vue-jwt-decode/-/vue-jwt-decode-0.1.0.tgz",
@@ -2871,6 +2946,48 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.0-5.tgz",
       "integrity": "sha512-aNmBT4bOecrFsZTog1l6AJDQHPP3ocXV+WQ3Ogy8WZCqstB/ahfhH4CPu5i4N9Hw0MBKXqE+LX+NbUxcj8cVTw==",
       "requires": {}
+    },
+    "@intlify/core-base": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.2.0-beta.26.tgz",
+      "integrity": "sha512-4OXSF0zC70UElev6gam4FdWfC7u4l2ouNK9Hc6R44QlpEXkzhbwwbpZn9gIGB2l11zQnJkAwaovfYyiNJ/JvkA==",
+      "requires": {
+        "@intlify/devtools-if": "9.2.0-beta.26",
+        "@intlify/message-compiler": "9.2.0-beta.26",
+        "@intlify/shared": "9.2.0-beta.26",
+        "@intlify/vue-devtools": "9.2.0-beta.26"
+      }
+    },
+    "@intlify/devtools-if": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-if/-/devtools-if-9.2.0-beta.26.tgz",
+      "integrity": "sha512-7GiF7v2jlHf7g5hoLF6sKlrX5Di2INfHN4PEAeVr2ashgoSaq1EYIRouBVAnJkOrDOJzCOEY7y53me7+gIbeTw==",
+      "requires": {
+        "@intlify/shared": "9.2.0-beta.26"
+      }
+    },
+    "@intlify/message-compiler": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.2.0-beta.26.tgz",
+      "integrity": "sha512-qtDgHCMqrXNTekKXGzm0Dm6r3+/X7/jFXP+E07hx+PJbPMv7DzK1iU8h5LlAMQ1/jr2UIRBgXvR5wh35OKoGrA==",
+      "requires": {
+        "@intlify/shared": "9.2.0-beta.26",
+        "source-map": "0.6.1"
+      }
+    },
+    "@intlify/shared": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.2.0-beta.26.tgz",
+      "integrity": "sha512-MjUlkjNThqkqy8yXUcFKBiW/hIfqAn5cP3Vd0b4wdOHS8rPCEbvSbAnF08uiZDkVv8gTcsLyymX21GaU6oYyyQ=="
+    },
+    "@intlify/vue-devtools": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-devtools/-/vue-devtools-9.2.0-beta.26.tgz",
+      "integrity": "sha512-Ghe2xTSezRzL2fBdIbZEus5+5spE2RMxgjBg6GyvbsDy1M05o2OvukBninJ4/Tc2I5A30lYgAsF1gQlOyfmv1g==",
+      "requires": {
+        "@intlify/core-base": "9.2.0-beta.26",
+        "@intlify/shared": "9.2.0-beta.26"
+      }
     },
     "@sendgrid/client": {
       "version": "7.6.0",
@@ -4789,6 +4906,17 @@
         "@vue/runtime-dom": "3.2.26",
         "@vue/server-renderer": "3.2.26",
         "@vue/shared": "3.2.26"
+      }
+    },
+    "vue-i18n": {
+      "version": "9.2.0-beta.26",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.2.0-beta.26.tgz",
+      "integrity": "sha512-xZgisyirT9hXFyXBL8pO8bYgdG7m98NLAUhbb1O9hMQS1qOXYU902+LIJA5k3BtoeiEIfjkGADHhSAlJTTzc9A==",
+      "requires": {
+        "@intlify/core-base": "9.2.0-beta.26",
+        "@intlify/shared": "9.2.0-beta.26",
+        "@intlify/vue-devtools": "9.2.0-beta.26",
+        "@vue/devtools-api": "^6.0.0-beta.13"
       }
     },
     "vue-jwt-decode": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mongoose": "^6.1.4",
     "nodemon": "^2.0.15",
     "vue": "^3.2.25",
+    "vue-i18n": "^9.2.0-beta.26",
     "vue-jwt-decode": "^0.1.0",
     "vue-router": "^4.0.12",
     "vue-select": "^4.0.0-beta.2",


### PR DESCRIPTION
- used vue-i18n-next via CDN
- the translations are currently within /src/i18n.js 
- minimal additions needed to the Vue components
- inside template tags, syntax looks like `{{ $t("about") }}` 
- this could be used for all of the app, if everyone agrees

![image](https://user-images.githubusercontent.com/78535490/148432590-b2628985-5d02-4a24-be30-10139f198f7b.png)
